### PR TITLE
Use encodeURIComponent rather than Buffer to uri-encode

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,6 +66,10 @@ var LT = /</g;
 var GT = />/g;
 var BS = /\\/g;
 var AST = /\*/g;
+var TILDE = /~/g;
+var BANG = /!/g;
+var LPAREN = /\(/g;
+var RPAREN = /\)/g;
 
 /**
  * Encodes values for safe embedding in HTML tags and attributes.
@@ -207,26 +211,15 @@ secureFilters.jsAttr = function(val) {
  * @return {string} the percent-encoded string
  */
 secureFilters.uri = function(val) {
-  var output = "";
-  var bytes = new Buffer(String(val), 'utf8'); // parse into utf8 bytes
-
-  for (var i = 0; i < bytes.length; i++) {
-    var c = bytes[i];
-    if (
-      (0x30 <= c && c <= 0x39) || // 0 .. 9
-      (0x41 <= c && c <= 0x5A) || // A .. Z
-      (0x61 <= c && c <= 0x7A) || // a .. z
-      (c === 0x2D) || // -
-      (c === 0x2E) || // .
-      (c === 0x5F)    // _
-    ) {
-      output += String.fromCharCode(c);
-    } else {
-      output += (c < 16 ? '%0' : '%') + c.toString(16).toUpperCase();
-    }
-  }
-
-  return output;
+  // "encodeURIComponent() will not encode ~!*()'"
+  var encode = encodeURIComponent(String(val));
+  return encode
+    .replace(BANG, '%21')
+    .replace(APOS, '%27')
+    .replace(LPAREN, '%28')
+    .replace(RPAREN, '%29')
+    .replace(AST, '%2A')
+    .replace(TILDE, '%7E');
 };
 
 /**

--- a/test.js
+++ b/test.js
@@ -19,6 +19,9 @@ var assert = require('assert');
 
 var secureFilters = require('./index');
 
+// Test character outside of the unicode BMP:
+var FACE_WITHOUT_MOUTH = "\uD83D\uDE36"; // U+1F636, UTF-8: F0 9F 98 B6
+
 var ALL_CASES = [
   {
     input: '&&amp;\'d',
@@ -56,11 +59,11 @@ var ALL_CASES = [
     uri: '%253Cscript%253E',
   },
   {
-    input: "é,ß,&☃",
-    html: "é,ß,&amp;☃",
-    js: "é,ß,&☃",
-    jsAttr: "é,ß,&amp;☃",
-    uri: '%C3%A9%2C%C3%9F%2C%26%E2%98%83',
+    input: "é,ß,&☃ "+FACE_WITHOUT_MOUTH,
+    html: "é,ß,&amp;☃ "+FACE_WITHOUT_MOUTH,
+    js: "é,ß,&☃ "+FACE_WITHOUT_MOUTH,
+    jsAttr: "é,ß,&amp;☃ "+FACE_WITHOUT_MOUTH,
+    uri: '%C3%A9%2C%C3%9F%2C%26%E2%98%83%20%F0%9F%98%B6',
   },
   {
     label: 'control characters',


### PR DESCRIPTION
Part of porting `secure-filters` to work client-side.  This PR replaces the use of node's `Buffer` class with the portable `encodeURIComponent()` function.
