### PR TITLE
Narrow HTML whitelist

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Contexts:
 a `<script>` or `<style>` block (plus other blocks that cannot have
 entity-encoded characters).
 
-Any character not matched by `/[\t\n\v\f\r ,\.0-9A-Z_a-z\-\u00A0-\uFFFF]/` is
+Any character not matched by `/[\t\n\v\f\r ,\.0-9A-Z_a-z\-\u00A0\uD800-\uDFFF]/` is
 replaced with an HTML entity.  Additionally, characters matched by
 `/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x9F]/` are converted to spaces to avoid
 browser quirks that interpret these as non-characters.

--- a/lib/secure-filters.js
+++ b/lib/secure-filters.js
@@ -62,9 +62,10 @@ var JSON_NOT_WHITELISTED = /[^\x22,\-\.0-9:A-Z\[\x5C\]_a-z{}]/g;
 // Control characters that get converted to spaces.
 var HTML_CONTROL = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x9F]/g;
 
-// Matches alphanum plus allowable whitespace, ",._-", and unicode.
-// NO-BREAK SPACE U+00A0 is fine since it's "whitespace".
-var HTML_NOT_WHITELISTED = /[^\t\n\v\f\r ,\.0-9A-Z_a-z\-\u00A0-\uFFFF]/g;
+// Matches alphanum plus allowable whitespace, ",._-", and Unicode U+10000 and higher.
+// \uD800-\uDFFF matches surrogate-pair characters, whitelisting U+10000 and higher.
+// NO-BREAK SPACE U+00A0 is also whitelisted since it's "whitespace".
+var HTML_NOT_WHITELISTED = /[^\t\n\v\f\r ,\.0-9A-Z_a-z\-\u00A0\uD800-\uDFFF]/g;
 
 // Matches alphanum and UTF-16 surrogate pairs (i.e. U+10000 and higher). The
 // rest of Unicode is deliberately absent in order to prevent charset encoding

--- a/test.js
+++ b/test.js
@@ -170,7 +170,7 @@ var ALL_CASES = [
   },
   {
     input: "é, ß, "+SNOWMAN+", "+FACE_WITHOUT_MOUTH,
-    html: "é, ß, "+SNOWMAN+", "+FACE_WITHOUT_MOUTH,
+    html: "&#xE9;, &#xDF;, &#x2603;, "+FACE_WITHOUT_MOUTH,
     js: "\\u00E9,\\x20\\u00DF,\\x20\\u2603,\\x20\\uD83D\\uDE36",
     jsAttr: "&#92;u00E9,&#92;x20&#92;u00DF,&#92;x20&#92;u2603,&#92;x20&#92;uD83D&#92;uDE36",
     uri: '%C3%A9%2C%20%C3%9F%2C%20%E2%98%83%2C%20%F0%9F%98%B6',


### PR DESCRIPTION
Narrow the Unicode whitelist in the HTML filter to only include U+A0 and U+10000-and-up (represented in UTF-16 as `D800`-`DFFF` surrogate-pairs).

Also simplifies the documentation to remove the redundant JSDoc commentary.
