### PR TITLE
double-quote is always URI-encoded

### DIFF
--- a/lib/secure-filters.js
+++ b/lib/secure-filters.js
@@ -43,7 +43,6 @@ secureFilters.configure = function(ejs) {
   return ejs;
 };
 
-var QUOT = /\x22/g; // "
 var APOS = /\x27/g; // '
 var AST = /\*/g;
 var TILDE = /~/g;
@@ -190,7 +189,6 @@ secureFilters.uri = function(val) {
   var encode = encodeURIComponent(String(val));
   return encode
     .replace(BANG, '%21')
-    .replace(QUOT, '%27')
     .replace(APOS, '%27')
     .replace(LPAREN, '%28')
     .replace(RPAREN, '%29')


### PR DESCRIPTION
Fairly sure that in all environments `"` will get encoded by `encodeURIComponent()` to `%22`.  The line removed is wrong (had `%27` instead of `%22`), but was getting masked by `encodeURIComponent` in all the test environments.
